### PR TITLE
Add try_scan and try_read macros which return a Result

### DIFF
--- a/examples/test_try_read.rs
+++ b/examples/test_try_read.rs
@@ -1,0 +1,34 @@
+#[macro_use] extern crate text_io;
+
+pub fn main() {
+    use std::error::Error;
+
+    fn parse_box_error() -> Result<i32, Box<Error>> {
+        // Parsing from stdio
+        Ok(try_read!("the answer™: {}")?)
+    }
+
+    let val = parse_box_error();
+    // Cannot match on `Ok` due to `Box<Error>` not implementing `PartialEq`, so we unwrap.
+    assert_eq!(val.unwrap(), 42);
+
+    fn parse_textio_error() -> Result<i32, text_io::Error> {
+        // Parsing a string literal
+        try_read!("the answer™: {}", "the answer™: 42".bytes())
+    }
+
+    let val = parse_textio_error();
+    assert_eq!(val, Ok(42));
+
+    let parse_closure = |input: &str| -> Result<i32, text_io::Error> {
+        // Parsing a string literal
+        try_read!("the answer™: {}", input.bytes())
+    };
+
+    let val = parse_closure("the answer™: abc");
+    // Failed to parse 'abc' into variable '__try_read_var__' (defined in the try_read macro)
+    assert_eq!(val, Err(text_io::Error::Parse("abc".into(), "__try_read_var__")));
+
+    let val = parse_closure("the answer™: 42");
+    assert_eq!(val, Ok(42));
+}

--- a/examples/test_try_scan.rs
+++ b/examples/test_try_scan.rs
@@ -1,0 +1,40 @@
+#[macro_use] extern crate text_io;
+
+pub fn main() {
+    use std::error::Error;
+
+    fn parse_box_error() -> Result<(i32, i32, i32), Box<Error>> {
+        // Parsing from stdio
+        let (a, b, c);
+        try_scan!("{}, {}\n{}", a, b, c);
+        Ok((a, b, c))
+    }
+
+    let val = parse_box_error();
+    // Cannot match on `Ok` due to `Box<Error>` not implementing `PartialEq`, so we unwrap.
+    assert_eq!(val.unwrap(), (99, 42, 66));
+
+    fn parse_textio_error() -> Result<(i32, i32, i32), text_io::Error> {
+        // Parsing a string literal
+        let (a, b, c);
+        try_scan!("99, 42\n66".bytes() => "{}, {}\n{}", a, b, c);
+        Ok((a, b, c))
+    }
+
+    let val = parse_textio_error();
+    assert_eq!(val, Ok((99, 42, 66)));
+
+    let parse_closure = |input: &str| -> Result<(i32, i32, i32), text_io::Error> {
+        // Parsing the closure input
+        let (a, b, c);
+        try_scan!(input.bytes() => "{}, {}\n{}", a, b, c);
+        Ok((a, b, c))
+    };
+
+    let val = parse_closure("99, abc\n66");
+    // Failed to parse 'abc' into variable 'b' (defined in the closure)
+    assert_eq!(val, Err(text_io::Error::Parse("abc".into(), "b")));
+
+    let val = parse_closure("99, 42\n66");
+    assert_eq!(val, Ok((99, 42, 66)));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,191 @@
 //!
 //! Note: only a single value can be read per `read!` invocation.
 
+use std::error;
+use std::fmt;
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    MissingMatch,
+    MissingClosingBrace,
+    UnexpectedValue(u8, Option<u8>),
+    InvalidUtf8(Vec<u8>),
+    PartialUtf8(usize, Vec<u8>),
+    Parse(String, &'static str),
+    #[doc(hidden)]
+    __NonExhaustive__,
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+
+        match *self {
+            MissingMatch => "Bad read! format string: did not contain {{}}",
+            MissingClosingBrace => "found single open curly brace at the end of the format string",
+            UnexpectedValue(..) => "found value not matching the pattern",
+            InvalidUtf8(..) => "input was not valid utf8",
+            PartialUtf8(..) => "input was only partially valid utf8",
+            Parse(..) => "could not parse input as target type",
+            __NonExhaustive__ => unreachable!(),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+        use std::str::from_utf8;
+
+        match *self {
+            InvalidUtf8(ref raw) => write!(f, "input was not valid utf8: {:?}", raw),
+            Parse(ref s, arg) => write!(f, "could not parse {} as target type of {}", s, arg),
+            UnexpectedValue(exp, act) => write!(
+                f,
+                "found value {:?} not matching the pattern value {}",
+                act.map(|b| b as char),
+                exp as char
+            ),
+            PartialUtf8(n, ref raw) => write!(
+                f,
+                "input was only partially valid utf8: \"{}\" followed by {:?}",
+                from_utf8(&raw[..n]).unwrap(),
+                &raw[n..]
+            ),
+            _ => write!(f, "{}", <Error as error::Error>::description(self)),
+        }
+    }
+}
+
+/// ```rust,no_run
+/// # #[macro_use]
+/// # extern crate text_io;
+/// # fn main() {
+/// let i: i32 = try_read!("The answer: {}!").unwrap();
+/// let i: Result<i32, _> = try_read!("The {}{{}}!", "The answer is 42!".bytes());
+/// assert!(i.is_err());
+/// # }
+/// ```
+///
+/// ```rust
+/// # #[macro_use]
+/// # extern crate text_io;
+/// # fn main() {
+/// let i: Result<i32, _> = try_read!("The answer is {}!", "The answer is 42!".bytes());
+/// assert!(i.is_ok());
+///
+/// let i: Result<i32, _> = try_read!("The {}{{}}!", "The answer is 42!".bytes());
+/// assert!(i.is_err());
+/// # }
+/// ```
+#[macro_export]
+macro_rules! try_read(
+    () => { try_read!("{}") };
+    ($text:expr) => {{
+        (|| -> Result<_, $crate::Error> {
+            let __try_read_var__;
+            try_scan!($text, __try_read_var__);
+            Ok(__try_read_var__)
+        })()
+    }};
+    ($text:expr, $input:expr) => {{
+        (|| -> Result<_, $crate::Error> {
+            let __try_read_var__;
+            try_scan!($input => $text, __try_read_var__);
+            Ok(__try_read_var__)
+        })()
+    }};
+);
+
+/// ```rust,no_run
+/// # #[macro_use]
+/// # extern crate text_io;
+/// # use std::error::Error;
+/// # fn main() {}
+/// fn parser() -> Result<i32, Box<Error>> {
+///     let i: i32;
+///     let text = "The answer is 42!";
+///
+///     try_scan!(text.bytes() => "The answer is {}!", i);
+///
+///     assert_eq!(i, 1);
+///     Ok(i)
+/// }
+/// ```
+#[macro_export]
+macro_rules! try_scan(
+    ($pattern:expr, $($arg:expr),*) => {
+        use ::std::io::Read;
+        try_scan!(::std::io::stdin().bytes().map(|c| c.unwrap()) => $pattern, $($arg),*) ;
+        format_args!($pattern, $($arg),*);
+    };
+    ($input:expr => $pattern:expr, $($arg:expr),*) => {{
+        use ::std::str::FromStr;
+        use $crate::Error;
+
+        fn match_next(expected: u8, iter: &mut Iterator<Item = u8>) -> Result<(), $crate::Error> {
+            let next = iter.next();
+            if next != Some(expected) {
+                return Err(Error::UnexpectedValue(expected, next))?
+            }
+            Ok(())
+        }
+
+        fn parse_capture<T>(name: &'static str, next: Option<u8>, iter: &mut Iterator<Item = u8>)
+        -> Result<T, $crate::Error>
+        where
+            T: FromStr,
+            <T as FromStr>::Err: ::std::fmt::Debug
+        {
+            static WHITESPACES: &'static [u8] = b"\t\r\n ";
+            let raw: Vec<u8> = match next {
+                Some(c) => iter.take_while(|&ch| ch != c).collect(),
+                None => iter
+                    .skip_while(|ch| WHITESPACES.contains(ch))
+                    .take_while(|ch| !WHITESPACES.contains(ch))
+                    .collect(),
+            };
+            match String::from_utf8(raw) {
+                Ok(s) => FromStr::from_str(&s).map_err(|_| Error::Parse(s, name)),
+                Err(e) => {
+                    let n = e.utf8_error().valid_up_to();
+                    let raw = e.into_bytes();
+                    if n == 0 {
+                        Err(Error::InvalidUtf8(raw))
+                    } else {
+                        Err(Error::PartialUtf8(n, raw))
+                    }
+                }
+            }
+        }
+
+        // typesafe macros :)
+        let pattern: &'static str = $pattern;
+        let stdin: &mut Iterator<Item = u8> = &mut ($input);
+
+        let mut pattern = pattern.bytes();
+
+        $(
+            $arg = loop {
+                match pattern.next().ok_or(Error::MissingMatch)? {
+                    b'{' => match pattern.next().ok_or(Error::MissingClosingBrace)? {
+                        b'{' => match_next(b'{', stdin)?,
+                        b'}' => break parse_capture(stringify!($arg), pattern.next(), stdin)?,
+                        _ => return Err(Error::MissingClosingBrace)?,
+                    },
+                    c => match_next(c, stdin)?,
+                }
+            };
+        )*
+
+        for c in pattern {
+            match_next(c, stdin)?
+        }
+
+        format_args!($pattern, $($arg),*);
+    }};
+);
+
 /// All text input is handled through this macro
 #[macro_export]
 macro_rules! read(

--- a/tests/tuple.rs
+++ b/tests/tuple.rs
@@ -24,6 +24,16 @@ fn run_read() {
 }
 
 #[test]
+fn run_try_read() {
+    test_str("target/debug/examples/test_try_read", "the answer™: 42");
+}
+
+#[test]
+fn run_try_scan() {
+    test_str("target/debug/examples/test_try_scan", "99, 42\n66");
+}
+
+#[test]
 fn run_read_simple() {
     test_str("target/debug/examples/test_read_simple", "99\n");
 }


### PR DESCRIPTION
It would be nice to be able to implement `scan!` in terms of `try_scan!` but it doesn't seem easy to do without some form of ident generation in the macro (to generate identifiers within a closure before assigning to the real idents after an unwrap). I welcome other contributors to attempt it though!

Closes #7.