### PR TITLE
`#[allow(clippy::try_err)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ macro_rules! try_scan(
         ($($e)+).unwrap()
     }};
     (@impl $action:tt; $input:expr => $pattern:expr, $($arg:expr),*) => {{
+        #![allow(clippy::try_err)]
         use $crate::{Error, match_next, parse_capture};
 
         // typesafe macros :)


### PR DESCRIPTION
Fixes #22.