### PR TITLE
Implement stdout flushing (#20)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@ macro_rules! try_read(
     }};
     ($text:expr, $input:expr) => {{
         (|| -> std::result::Result<_, $crate::Error> {
+            use std::io::Write;
+            std::io::stdout().flush().unwrap();
             let __try_read_var__;
             $crate::try_scan!($input => $text, __try_read_var__);
             Ok(__try_read_var__)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,8 @@ macro_rules! try_read(
     () => { $crate::try_read!("{}") };
     ($text:expr) => {{
         (|| -> std::result::Result<_, $crate::Error> {
+            use std::io::Write;
+            std::io::stdout().flush().unwrap();
             let __try_read_var__;
             $crate::try_scan!($text, __try_read_var__);
             Ok(__try_read_var__)


### PR DESCRIPTION
This implements ```stdout().flush()``` to ```try_read!``` (along with ```read!``` since it just invokes and unwraps ```try_read!```) in response to Issue #20 .
Example code:
```rust,no_run
fn main() {
    print!("Input value: ");
    let test: i32 = try_read!().unwrap_or(-1);
    println!("Value: {}", test);
}
```
Normally this would output:
```
(NUMBER)
Input value: Value: (NUMBER)
```
With these changes, we now get:
```
Input value: (NUMBER)
Value: (NUMBER)
```